### PR TITLE
Support for targeted interaction with multiple Blynclights

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,21 +32,35 @@ func main() {
 
 	light := blync.NewBlyncLight()
 	time.Sleep(time.Second * 2)
-	light.SetColor(blync.Red)
-	light.Play(52)
+	//flash all lights in order based on USB path
+	light.FlashOrder()
+
+	// set all lights connected to red with music
+	light.SetColor(blync.Red,0)
+	light.Play(52,0)
 	time.Sleep(time.Second * 5)
-	light.SetColor(blync.Blue)
+	light.StopPlay(0)
+
+	//set only first blync light to blue
+	light.SetColor(blync.Blue,1)
 	time.Sleep(time.Second * 5)
-	light.StopPlay()
-	light.Reset()
+
+	//reset all blynclights
+	light.Reset(0)
+
 
 	for i := 0; i < 256; i++ {
-		light.SetColor([3]byte{byte(i), 255 - byte(i), 0x00})
+		light.SetColor([3]byte{byte(i), 255 - byte(i), 0x00},0)
 		time.Sleep(13 * time.Millisecond)
 	}
-	light.SetBlinkRate(blync.BlinkMedium)
+	light.SetBlinkRate(blync.BlinkMedium,0)
 	time.Sleep(time.Second * 5)
-	light.Close()
+	light.Close() //Close always affects all lights
 }
 
 ```
+
+### Note on multiple BlyncLights.
+Blync lights are ordered based on USB ID.  You can use system info based on your OS tools, or call light.flashOrder().
+
+When calling subsequent blynclight functions use 0 to interact with all, or specific ID starting as 1 based on relative order.

--- a/blync.go
+++ b/blync.go
@@ -92,7 +92,6 @@ func (b BlyncLight) sendFeatureReport(id int) {
 		device := b.devices[index]
 		b.write(device)
 	}
-
 }
 
 func (b BlyncLight) write(device hid.Device){

--- a/blync.go
+++ b/blync.go
@@ -95,7 +95,7 @@ func (b BlyncLight) sendFeatureReport(id int) {
 }
 
 func (b BlyncLight) write(device hid.Device){
-	error := device.WriteInterrupt(b.bytes)
+	error := device.WriteInterrupt(byte(3),b.bytes)
 	if error != nil {
 		fmt.Println(error)
 	}

--- a/blync.go
+++ b/blync.go
@@ -95,7 +95,7 @@ func (b BlyncLight) sendFeatureReport(id int) {
 }
 
 func (b BlyncLight) write(device hid.Device){
-	error := device.WriteInterrupt(byte(3),b.bytes)
+	error := device.Write(b.bytes)
 	if error != nil {
 		fmt.Println(error)
 	}

--- a/blync.go
+++ b/blync.go
@@ -95,7 +95,7 @@ func (b BlyncLight) sendFeatureReport(id int) {
 }
 
 func (b BlyncLight) write(device hid.Device){
-	error := device.WriteFeature(b.bytes)
+	error := device.WriteInterupt(b.bytes)
 	if error != nil {
 		fmt.Println(error)
 	}

--- a/blync.go
+++ b/blync.go
@@ -95,7 +95,7 @@ func (b BlyncLight) sendFeatureReport(id int) {
 }
 
 func (b BlyncLight) write(device hid.Device){
-	error := device.Write(b.bytes)
+	error := device.WriteFeature(b.bytes)
 	if error != nil {
 		fmt.Println(error)
 	}

--- a/blync.go
+++ b/blync.go
@@ -95,7 +95,7 @@ func (b BlyncLight) sendFeatureReport(id int) {
 }
 
 func (b BlyncLight) write(device hid.Device){
-	error := device.WriteInterupt(b.bytes)
+	error := device.WriteInterrupt(b.bytes)
 	if error != nil {
 		fmt.Println(error)
 	}


### PR DESCRIPTION
Previously this library would blast all connected lights.  Now each light is assigned an ID based on the order of the assigned USB path from the OS.

Clients may call a new method to see the order, which is also printed when the HID devices are scanned.

Updated readme with notes and updated code example to match.
